### PR TITLE
Update star history chart link

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@
 
 ## 星标历史
 
-<a href="https://www.star-history.com/#mytv-android/mytv-android&Date">
+<a href="https://star-history.dera.page/#mytv-android/mytv-android&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=mytv-android/mytv-android&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=mytv-android/mytv-android&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=mytv-android/mytv-android&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mytv-android/mytv-android&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mytv-android/mytv-android&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=mytv-android/mytv-android&type=Date" />
  </picture>
 </a>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -64,11 +64,11 @@ For communication (this group is generally not for bug feedback or suggestions, 
 
 ## Star History
 
-<a href="https://www.star-history.com/#mytv-android/mytv-android&Date">
+<a href="https://star-history.dera.page/#mytv-android/mytv-android&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=mytv-android/mytv-android&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=mytv-android/mytv-android&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=mytv-android/mytv-android&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mytv-android/mytv-android&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mytv-android/mytv-android&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=mytv-android/mytv-android&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The current star history chart is broken because the underlying service can no longer fetch stargazer data reliably. This PR points the chart to a new domain that resolves the issue and keeps the star history chart working for this repository.